### PR TITLE
Correct documentation of the check name

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ In the Pull Request, you will notice that the CodeQL Analysis has started as a s
 
 #### Security Alert Details
 
-After the Workflow has completed click on `Details` by the `Code Scanning Results / CodeQL` status check. 
+After the Workflow has completed click on `Details` by the `Code scanning results / CodeQL` status check. 
 
 <img src="https://user-images.githubusercontent.com/6920330/96752487-85781f00-139c-11eb-943d-602f2de98998.png" width="80%"/>
 


### PR DESCRIPTION
This is not a big deal, but the check name is `Code scanning results / CodeQL` instead of `Code Scanning Results / CodeQL`. This caused problems for me when I was configuring branch protection rules.